### PR TITLE
Blacklist techreborn:alarm to allow changing the sound

### DIFF
--- a/config/carrier.json
+++ b/config/carrier.json
@@ -3,5 +3,5 @@
   "slownessLevel": 2,
   "hungerExhaustion": 0.05,
   "type": "BLACKLIST",
-  "list": ["waystones", "comforts", "infusion_table:infusion_table", "yigd:grave", "arcanus:display_case", "ae2", "create"]
+  "list": ["waystones", "comforts", "infusion_table:infusion_table", "yigd:grave", "arcanus:display_case", "ae2", "create", "techreborn:alarm"]
 }


### PR DESCRIPTION
Tech Reborn's alarm uses the shift+rightclick interaction to change
the sound of the alarm. This conflicts with carrier